### PR TITLE
The published behavior in the utils plugin doesnt handle the published_date correctly

### DIFF
--- a/models/behaviors/publishable.php
+++ b/models/behaviors/publishable.php
@@ -56,6 +56,9 @@ class PublishableBehavior extends ModelBehavior {
 				$id = $Model->id;
 			}
 
+			$onFind = $this->__settings[$Model->alias]['find'];
+			$this->enablePublishable($Model, false);
+
 			$data = array($Model->alias => array(
 				$Model->primaryKey => $id,
 				$this->__settings[$Model->alias]['field'] => true
@@ -63,17 +66,14 @@ class PublishableBehavior extends ModelBehavior {
 
 			$Model->id = $id;
 			if (isset($this->__settings[$Model->alias]['field_date']) && $Model->hasField($this->__settings[$Model->alias]['field_date'])) {
-				if (!$Model->exists()) {
-					$data[$Model->alias][$this->__settings[$Model->alias]['field_date']] = date('Y-m-d');
+				if (!$Model->field($this->__settings[$Model->alias]['field_date'])) {
+					$data[$Model->alias][$this->__settings[$Model->alias]['field_date']] = date('Y-m-d H:i:s');
 				}
 			}
 
 			if (!empty($attributes)) {
 				$data[$Model->alias] = array_merge($data[$Model->alias], $attributes);
 			}
-
-			$onFind = $this->__settings[$Model->alias]['find'];
-			$this->enablePublishable($Model, false);
 
 			$result = $Model->save($data, false, array_keys($data[$Model->alias]));
 			$this->enablePublishable($Model, 'find', $onFind);


### PR DESCRIPTION
Now it checks the existing published_date value in the model to see if it needs to save a new date.

Fixed issue where the published date field is not correctly filled in when publishing the model
