### PR TITLE
InheritableBehavior CakePHP 2 find() fix

### DIFF
--- a/models/behaviors/inheritable.php
+++ b/models/behaviors/inheritable.php
@@ -194,8 +194,8 @@ class InheritableBehavior extends ModelBehavior {
  */
 	protected function _singleTableBeforeFind(Model $Model, $query) {
 		extract($this->settings[$Model->alias]);
-
-		if (isset($Model->_schema[$inheritanceField]) && $Model->alias != $Model->parent->alias) {
+		$_schema = $Model->schema();
+		if (isset($_schema[$inheritanceField]) && $Model->alias != $Model->parent->alias) {
 			$field = $Model->alias. '.' . $inheritanceField;
 
 			if (!isset($query['conditions'])) {


### PR DESCRIPTION
This fixes a problem with find(), which ignored 'type' column and always returned everything from the database.

Sorry for the previous pull :)
