### PR TITLE
Making SluggableBehaviour return true in beforeSave()

### DIFF
--- a/Model/Behavior/SluggableBehavior.php
+++ b/Model/Behavior/SluggableBehavior.php
@@ -73,16 +73,16 @@ class SluggableBehavior extends ModelBehavior {
 		$settings = $this->settings[$Model->alias];
 		if (is_string($this->settings[$Model->alias]['trigger'])) {
 			if ($Model->{$this->settings[$Model->alias]['trigger']} != true) {
-				return;
+				return true;
 			}
 		}
 
 		if (empty($Model->data[$Model->alias])) {
-			return;
+			return true;
 		} else if (empty($Model->data[$Model->alias][$this->settings[$Model->alias]['label']])) {
-			return;
+			return true;
 		} else if (!$this->settings[$Model->alias]['update'] && !empty($Model->id) && !is_string($this->settings[$Model->alias]['trigger'])) {
-			return;
+			return true;
 		}
 
 		$slug = $Model->data[$Model->alias][$settings['label']];


### PR DESCRIPTION
Title says it all. Normal model saves were failing because the behaviour beforeSave() was returning null and not true.

Sorry it is over 2 commits, I did it ages ago but forgot to pull request, code has changed greatly since then anyway.
