### PR TITLE
SoftDeleteBehavior does not call beforeDelete on the base Model

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -1,4 +1,4 @@
-<?php 
+<?php
 /**
  * Copyright 2007-2010, Cake Development Corporation (http://cakedc.com)
  *
@@ -103,10 +103,12 @@ class SoftDeleteBehavior extends ModelBehavior {
  * @param array $query
  * @return boolean
  */
-    public function beforeDelete($model) {
+    public function beforeDelete($model, $cascade = true) {
         $runtime = $this->runtime[$model->alias];
         if ($runtime) {
-        	$res = $this->delete($model, $model->id);
+        	if ($model->beforeDelete($cascade)) {
+        	  $res = $this->delete($model, $model->id);
+        	}
             return false;
         } else {
 			return true;
@@ -209,7 +211,7 @@ class SoftDeleteBehavior extends ModelBehavior {
     public function purgeDeletedCount($model, $expiration = '-90 days') {
         $this->softDelete($model, false);
         return $model->find('count', array(
-			'conditions' => $this->_purgeDeletedConditions($model, $expiration), 
+			'conditions' => $this->_purgeDeletedConditions($model, $expiration),
 			'recursive' => -1));
     }
 
@@ -223,8 +225,8 @@ class SoftDeleteBehavior extends ModelBehavior {
     public function purgeDeleted($model, $expiration = '-90 days') {
         $this->softDelete($model, false);
         $records = $model->find('all', array(
-			'conditions' => $this->_purgeDeletedConditions($model, $expiration), 
-			'fields' => array($model->primaryKey), 
+			'conditions' => $this->_purgeDeletedConditions($model, $expiration),
+			'fields' => array($model->primaryKey),
 			'recursive' => -1));
         if ($records) {
             foreach ($records as $record) {

--- a/Test/Case/Model/Behavior/SoftDeleteTest.php
+++ b/Test/Case/Model/Behavior/SoftDeleteTest.php
@@ -49,6 +49,12 @@ class SoftDeletedPost extends CakeTestModel {
  * @var string
  */
 	public $alias = 'Post';
+
+
+	public $beforeDeleteReturnValue = true;
+	public function beforeDelete($cascade = true) {
+		return $this->beforeDeleteReturnValue;
+	}
 }
 
 /**
@@ -129,12 +135,24 @@ class SoftDeleteTest extends CakeTestCase {
 		$count = $this->Post->purgeDeletedCount();
 		$this->assertEqual($count, 1);
 		$this->Post->purgeDeleted();
-		
+
 		$data = $this->Post->read(null, 3);
 		$this->assertFalse($data);
 		$this->Post->Behaviors->disable('SoftDelete');
 		$data = $this->Post->read(null, 3);
 		$this->assertFalse($data);
+	}
+
+	public function testBeforeDelete() {
+		$this->Post->beforeDeleteReturnValue = false;
+
+		$data = $this->Post->read(null, 1);
+		$this->assertEqual($data[$this->Post->alias][$this->Post->primaryKey], 1);
+		$result = $this->Post->delete(1);
+
+		// delete should have failed
+		$data = $this->Post->read(null, 1);
+		$this->assertEqual($data[$this->Post->alias][$this->Post->primaryKey], 1);
 	}
 
 }


### PR DESCRIPTION
SoftDeleteBehavior does not call beforeDelete on the base Model.  As a result, records that would not be hard deleted can be soft deleted.  
