### PR TITLE
Fixing PingbackableBehaviour parse error

### DIFF
--- a/Model/Behavior/PingbackableBehavior.php
+++ b/Model/Behavior/PingbackableBehavior.php
@@ -61,7 +61,7 @@ class PingbackableBehavior extends ModelBehavior {
 		if (!isset($this->settings[$model->alias])) {
 			$this->settings[$model->alias] = $this->defaults;
 		}
-		$this->settings[$model->alias] = am($this->settings[$model->alias], empty(is_array($settings)) ? $settings : array());
+		$this->settings[$model->alias] = am($this->settings[$model->alias], is_array($settings) ? $settings : array());
 	}
 
 /**


### PR DESCRIPTION
Seems like the PingBackable behaviour wasn't tested at least through lint:

php -l PingbackableBehavior.php 
PHP Fatal error: Can't use function return value in write context in PingbackableBehavior.php on line 63
Errors parsing PingbackableBehavior.php

This was using caused by using the return of is_array() in empty().
