### PR TITLE
Fix for syntax error in RegisterException.

### DIFF
--- a/Model/Behavior/RegisterException.php
+++ b/Model/Behavior/RegisterException.php
@@ -57,7 +57,7 @@ class PingbackableBehavior extends ModelBehavior {
 		if (!isset($this->settings[$model->alias])) {
 			$this->settings[$model->alias] = $this->defaults;
 		}
-		$this->settings[$model->alias] = am($this->settings[$model->alias], !empty(is_array($settings)) ? $settings : array());
+		$this->settings[$Model->alias] = array_merge($this->settings[$Model->alias], (array)$settings);
 	}
 
 /**


### PR DESCRIPTION
Needed a small fix to pass PHP linter.

```
> php -l RegisterException.php 
PHP Fatal error:  Can't use function return value in write context in RegisterException.php on line 60
Errors parsing RegisterException.php
```
