### PR TITLE
soft delete using id that does not exist in db

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -155,8 +155,20 @@ class SoftDeleteBehavior extends ModelBehavior {
 			}
 		}
 
-		$record = $model->read($model->primaryKey, $id);
-		return empty($record) || $model->save(array($model->alias => $data), false, array_keys($data));
+		$record = $model->find('first', array(
+			'fields' => $model->primaryKey,
+			'conditions' => array($model->primaryKey => $id),
+			'recursive' => -1
+		));
+
+		if (!empty($record)) {
+			$model->set($model->primaryKey, $id);
+			unset($model->data[$model->alias]['modified']);
+			unset($model->data[$model->alias]['updated']);
+			return $model->save(array($model->alias => $data), false, array_keys($data));
+		}
+
+		return true;
 	}
 
 /**

--- a/Test/Case/Model/Behavior/SoftDeleteTest.php
+++ b/Test/Case/Model/Behavior/SoftDeleteTest.php
@@ -101,6 +101,25 @@ class SoftDeleteTest extends CakeTestCase {
 	}
 
 /**
+ * testSoftDeleteWhenModelDataIsEmpty
+ *
+ * @return void
+ */
+	public function testSoftDeleteWhenModelDataIsEmpty() {
+		$data = $this->Post->find('first', array('conditions' => array($this->Post->primaryKey => 1)));
+		$this->assertEqual($data[$this->Post->alias][$this->Post->primaryKey], 1);
+		$this->assertTrue(empty($this->Post->data));
+		$result = $this->Post->delete(1);
+		$this->assertFalse($result);
+		$data = $this->Post->read(null, 1);
+		$this->assertTrue(empty($data));
+		$this->Post->Behaviors->unload('SoftDelete');
+		$data = $this->Post->read(null, 1);
+		$this->assertEqual($data['Post']['deleted'], true);
+		$this->assertEqual($data['Post']['updated'], $data['Post']['deleted_date']);
+	}
+
+/**
  * testSoftDeleteUsingIdThatDoesNotExist
  *
  * @return void


### PR DESCRIPTION
The current implementation will try to create a new record when id is
not in the database.  Included are a test that demonstrates this issue
and a fix.

Note: Model->read() actually returns false, not array(), when a record
is not found.
http://api.cakephp.org/2.1/class-Model.html#_read
