### PR TITLE
Update TinySluggableBehavior.php

### DIFF
--- a/Model/Behavior/TinySluggableBehavior.php
+++ b/Model/Behavior/TinySluggableBehavior.php
@@ -44,7 +44,7 @@ class TinySluggableBehavior extends ModelBehavior {
  * 	- tinySlug: name of the tiny slug field in the table [default: tiny_slug]
  *  - codeset: valid characters for tiny slug [default: 0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ]
  */
-	public function setup(&$Model, $settings = array()) {
+	public function setup(Model $Model, $settings = array()) {
 		$this->settings[$Model->alias] = array_merge($this->_defaults, $settings);
 		$Model->tinySlug = $this->settings[$Model->alias]['tinySlug'];
 		$this->settings[$Model->alias]['base'] = strlen($this->settings[$Model->alias]['codeset']);
@@ -55,7 +55,7 @@ class TinySluggableBehavior extends ModelBehavior {
  *
  * @param object $Model
  */
-	public function beforeSave(&$Model) {
+	public function beforeSave(Model $Model) {
 		if (empty($Model->data[$Model->alias])) {
 			return;
 		}


### PR DESCRIPTION
Prevents error like:

Strict (2048): Declaration of TinySluggableBehavior::setup() should be compatible with ModelBehavior::setup(Model $model, $config = Array) [APP/Plugin/Utils/Model/Behavior/TinySluggableBehavior.php, line 138]
Strict (2048): Declaration of TinySluggableBehavior::beforeSave() should be compatible with ModelBehavior::beforeSave(Model $model) [APP/Plugin/Utils/Model/Behavior/TinySluggableBehavior.php, line 138]
Strict (2048): Only variables should be passed by reference [CORE/Cake/Model/BehaviorCollection.php, line 150]
