### PR TITLE
ToggleableBehavior check record fix

### DIFF
--- a/Model/Behavior/ToggleableBehavior.php
+++ b/Model/Behavior/ToggleableBehavior.php
@@ -89,7 +89,7 @@ class ToggleableBehavior extends ModelBehavior {
 			$newState = $fields[$field][0];
 		}
 
-		if ($checkRecord != false && !$Model->exists(true)) {
+		if ($checkRecord != false && !$Model->exists($id)) {
 			$message = __d('utils', 'Invalid record');
 			if (is_string($checkRecord)) {
 				$message = $checkRecord;


### PR DESCRIPTION
Model::exists(true) usage was wrong. Model:exists() only accepts null (which is default), false and primary key value. So true is converted to "1". And it was always checking the record which its primary key value is always "1".
