### PR TITLE
Entities will still be deleted

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -127,7 +127,8 @@ class SoftDeleteBehavior extends ModelBehavior {
 		$runtime = $this->runtime[$model->alias];
 		if ($runtime) {
 			if ($model->beforeDelete($cascade)) {
-				return $this->delete($model, $model->id);
+				$this->delete($model, $model->id);
+				return false;
 			}
 			return false;
 		}


### PR DESCRIPTION
This change returns false for beforeDelete so the actual deletion behaviour is turned off. Otherwise it would have returned true and entities were still deleted.
