### PR TITLE
SoftDelete not working issue. BeforeDelete is supposed to return false?

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -127,7 +127,7 @@ class SoftDeleteBehavior extends ModelBehavior {
 		$runtime = $this->runtime[$model->alias];
 		if ($runtime) {
 			if ($model->beforeDelete($cascade)) {
-				return $this->delete($model, $model->id);
+				return !$this->delete($model, $model->id);
 			}
 			return false;
 		}


### PR DESCRIPTION
To prevent default delete behavior to remove the record, the beforeDelete callback should return false after saving delete = 1 and deleted_date = xxxxxxx

It actually returns:
```$this->delete() that returns $this->save() --> true```
and  makes the record to be removed from database.

Is my first contribution with Cake DC, so, please, excuse me if I am wrong or my english is not good enough.