### PR TITLE
Added missing contain in finder

### DIFF
--- a/Model/Behavior/TinySluggableBehavior.php
+++ b/Model/Behavior/TinySluggableBehavior.php
@@ -100,6 +100,7 @@ class TinySluggableBehavior extends ModelBehavior {
 				}
 				$new = $this->__toShort($Model, $this->__toDecimal($Model, $new) + 1);
 				$existing = $Model->find('count', array(
+					'contain' => array(),
 					'conditions' => array(
 						$Model->alias . '.' . $Model->tinySlug => $new)));
 				$attempts++;


### PR DESCRIPTION
Added this missing contain statement as I have this behavior attached to a crazy modal with a lot of associations.  This is improves performance for me, and should not affect how this behavior works for anybody else.