### PR TITLE
SoftDelete: Behaviors->attached is deprecated. should use Behaviors->loaded instead

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -85,7 +85,7 @@ Since "exists" method in Model disable callbacks you may experience problems usi
 ```php
 <?php
 public function exists($id = null) {
-	if ($this->Behaviors->attached('SoftDelete')) {
+	if ($this->Behaviors->loaded('SoftDelete')) {
 		return $this->existsAndNotDeleted($id);
 	} else {
 		return parent::exists($id);


### PR DESCRIPTION
Hi all,

Behaviors->attached will be removed in CakePHP 3.0.  It probably doesn't matter for 2.x but my linter warned me about using Behaviors->attached.

For keeping confusion to minimum, I thought the document should be updated.
Thanks in advance.
