### PR TITLE
Issue #147 fix for Unit Tests fail if SoftDelete Behavior is attached.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-This repository follows the [CakeDC Plugin Standard](http://cakedc.com/plugin-standard). If you'd like to contribute new features, enhancements or bug fixes to the plugin, please read our [Contribution Guidelines](http://cakedc.com/plugins) for detailed instructions.
+This repository follows the [CakeDC Plugin Standard](http://cakedc.com/plugin-standard). If you'd like to contribute new features, enhancements or bug fixes to the plugin, please read our [Contribution Guidelines](http://cakedc.com/plugin-standard) for detailed instructions.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
 Contributing
 ============
 
-This repository follows the [CakeDC Plugin Standard](http://cakedc.com/plugins). If you'd like to contribute new features, enhancements or bug fixes to the plugin, please read our [Contribution Guidelines](http://cakedc.com/plugins) for detailed instructions.
+This repository follows the [CakeDC Plugin Standard](http://cakedc.com/plugin-standard). If you'd like to contribute new features, enhancements or bug fixes to the plugin, please read our [Contribution Guidelines](http://cakedc.com/plugins) for detailed instructions.


### PR DESCRIPTION
Bug was first described in #138. Was partially fixed in #139. But the fix is incomplete, and also breaks relationships that use aliases (described in #147).

With the proposed changes, the behavior will not become active if the table is missing, and -thus- will not attempt to run $model->hasField($flag), responsible for the MissingTableExceptions. The only scenario in which I believe this missing table issue happens is in unit testing, when relationships are loaded before fixtures. This fix should not affect normal operation.
