### PR TITLE
Fix InheritableBehavior and Tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,21 +12,21 @@ env:
     - REQUIRE="phpunit/phpunit:3.7.31"
 
   matrix:
-    - DB=mysql CAKE_VERSION=2.4
+    - DB=mysql CAKE_VERSION=2.7
 
 matrix:
   include:
     - php: 5.3
       env:
-        - CAKE_VERSION=2.4
+        - CAKE_VERSION=2.7
         - COVERALLS=1
     - php: 5.4
       env:
-        - CAKE_VERSION=2.4
+        - CAKE_VERSION=2.7
         - COVERALLS=1
     - php: 5.5
       env:
-        - CAKE_VERSION=2.4
+        - CAKE_VERSION=2.7
         - COVERALLS=1
 
 before_script:

--- a/Model/Behavior/InheritableBehavior.php
+++ b/Model/Behavior/InheritableBehavior.php
@@ -63,6 +63,7 @@ class InheritableBehavior extends ModelBehavior {
 		if ($this->settings[$Model->alias]['method'] == InheritableBehavior::CTI) {
 			$this->classTableBindParent($Model);
 		}
+		$Model->validate = array_merge($Model->validate, $Model->parent->validate);
 	}
 
 /**
@@ -108,26 +109,26 @@ class InheritableBehavior extends ModelBehavior {
 						$results[$i][$Model->alias] = array_merge($res[$Model->parent->alias], $res[$Model->alias]);
 						unset($results[$i][$Model->parent->alias]);
 
-					} elseif (!empty($res[$Model->alias][$Model->parent->alias])) {
-						$results[$i][$Model->alias] = array_merge($res[$Model->alias][$Model->parent->alias], $res[$Model->alias]);
-						unset($results[$i][$Model->alias][$Model->parent->alias]);
+					} elseif (!empty($res[$Model->alias][$Model->parent->name])) {
+						$results[$i][$Model->alias] = array_merge($res[$Model->alias][$Model->parent->name], $res[$Model->alias]);
+						unset($results[$i][$Model->alias][$Model->parent->name]);
 
 					} elseif (!empty($res[$Model->alias][0])) {
 						foreach ($res[$Model->alias] as $j => $subRes) {
-							if (isset($subRes[$Model->parent->alias])) {
-								$results[$i][$Model->alias][$j] = array_merge($subRes[$Model->parent->alias], $subRes);
-								unset($results[$i][$Model->alias][$j][$Model->parent->alias]);
+							if (isset($subRes[$Model->parent->name])) {
+								$results[$i][$Model->alias][$j] = array_merge($subRes[$Model->parent->name], $subRes);
+								unset($results[$i][$Model->alias][$j][$Model->parent->name]);
 							}
 						}
 					}
-				} elseif ($i == $Model->parent->alias) {
+				} elseif ($i == $Model->parent->name) {
 					$results = array_merge($results, $res);
 					unset($results[$i]);
 				} elseif ($i == $Model->alias && array_key_exists(0, $res)) {
 					foreach ($res as $j => $payload) {
-						if (array_key_exists($Model->parent->alias, $payload)) {
-							$results[$i][$j] = array_merge($payload, $payload[$Model->parent->alias]);
-							unset($results[$i][$j][$Model->parent->alias]);
+						if (array_key_exists($Model->parent->name, $payload)) {
+							$results[$i][$j] = array_merge($payload, $payload[$Model->parent->name]);
+							unset($results[$i][$j][$Model->parent->name]);
 						}
 					}
 				}

--- a/Test/Case/Model/Behavior/CsvImportTest.php
+++ b/Test/Case/Model/Behavior/CsvImportTest.php
@@ -85,7 +85,7 @@ class CsvImportTest extends CakeTestCase {
 	public function testImportCSV() {
 		$this->Content->Behaviors->load('Utils.CsvImport');
 		$path = App::pluginPath('Utils');
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv');
 		$this->assertTrue($result);
 
 		$records = $this->Content->find('all', array('order' => 'created DESC', 'limit' => 2));
@@ -110,7 +110,7 @@ class CsvImportTest extends CakeTestCase {
 		), false);
 		$this->Content->Behaviors->load('Utils.CsvImport');
 		$path = App::pluginPath('Utils');
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test2.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test2.csv');
 		$this->assertTrue($result);
 
 		$records = $this->Content->find('all', array('order' => 'created DESC', 'limit' => 2));
@@ -131,7 +131,7 @@ class CsvImportTest extends CakeTestCase {
 		$this->Content = new ContentCallback();
 		$this->Content->Behaviors->load('Utils.CsvImport');
 		$path = App::pluginPath('Utils');
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv');
 		$this->assertTrue($result);
 
 		$records = $this->Content->find('all', array('order' => 'created DESC', 'limit' => 2));
@@ -149,7 +149,7 @@ class CsvImportTest extends CakeTestCase {
 		$this->Content->Behaviors->load('Utils.CsvImport');
 		$path = App::pluginPath('Utils');
 		$fixed = array('Content' => array('parent_id' => 10));
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv', $fixed);
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv', $fixed);
 		$this->assertTrue($result);
 
 		$records = $this->Content->find('all', array('order' => 'created DESC', 'limit' => 2));
@@ -169,7 +169,7 @@ class CsvImportTest extends CakeTestCase {
 		$this->Content->validate = array(
 			'title' => array(
 				'long' => array('rule' => array('minLength', 100))));
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv');
 		$this->assertFalse($result);
 		$errors = $this->Content->getImportErrors();
 		$expected = array(
@@ -192,7 +192,7 @@ class CsvImportTest extends CakeTestCase {
 			'type' => array(
 				'list' => array('rule' => array('inList', array('Article')))));
 
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv', array(), true);
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv', array(), true);
 		$this->assertEquals($result, array(0)); // The numbers of the rows that were saved
 
 		$errors = $this->Content->getImportErrors();
@@ -218,7 +218,7 @@ class CsvImportTest extends CakeTestCase {
 		$mock->expects($this->exactly(2))->method('onImportRow');
 		$mock->expects($this->exactly(2))->method('listen');
 
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test1.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test1.csv');
 		$this->assertTrue($result);
 	}
 
@@ -231,7 +231,7 @@ class CsvImportTest extends CakeTestCase {
 	public function testImportCSVWithEmptyLines() {
 		$this->Content->Behaviors->load('Utils.CsvImport', array('skipEmpty' => true));
 		$path = App::pluginPath('Utils');
-		$result = $this->Content->importCSV($path . 'Test' . DS . 'tmp' . DS . 'test3.csv');
+		$result = $this->Content->importCSV($path . 'Test' . DS . 'Tmp' . DS . 'test3.csv');
 		$this->assertTrue($result);
 
 		$records = $this->Content->find('all', array('order' => 'created DESC', 'limit' => 2));

--- a/Test/Case/Model/Behavior/InheritableTest.php
+++ b/Test/Case/Model/Behavior/InheritableTest.php
@@ -38,13 +38,8 @@ class InheritableAsset extends CakeTestModel {
 
 	public $name = 'Asset';
 
-	public $validate = array('title' => array('rule' => 'notEmpty'));
-}
-
-class Asset extends CakeTestModel {
-
 	public $validate = array(
-		'title' => array('rule' => 'notEmpty'),
+		'title' => array('rule' => 'notBlank'),
 		'expiration' => array('rule' => 'date', 'allowEmpty' => true)
 	);
 }
@@ -55,7 +50,7 @@ class InheritableLink extends InheritableAsset {
 
 	public $actsAs = array('Utils.Inheritable' => array('method' => 'CTI'));
 
-	public $validate = array('url' => array('rule' => 'notEmpty'));
+	public $validate = array('url' => array('rule' => 'notBlank'));
 }
 
 class InheritableImage extends InheritableAsset {
@@ -97,17 +92,18 @@ class InheritableTest extends CakeTestCase {
 		parent::setUp();
 
 		// STI models
-		$this->Article = ClassRegistry::init('InheritableArticle');
-		$this->Page = ClassRegistry::init('InheritablePage');
-		$this->Content = ClassRegistry::init('InheritableContent');
+		$this->Article = ClassRegistry::init(array('class'=>'InheritableArticle', 'alias'=>'Article'));
+		$this->Page = ClassRegistry::init(array('class'=>'InheritablePage', 'alias'=>'Page'));
+		$this->Content = ClassRegistry::init(array('class'=>'InheritableContent'));
 
 		$this->Page->Behaviors->load('Containable');
 		$this->Article->Behaviors->load('Containable');
 
 		// CTI models
-		$this->Asset = ClassRegistry::init('InheritableAsset');
-		$this->Link = ClassRegistry::init('InheritableLink');
-		$this->Image = ClassRegistry::init('InheritableImage');
+		$this->Asset = ClassRegistry::init(array('class'=>'InheritableAsset', 'alias'=>'Asset'));
+		$this->Link = ClassRegistry::init(array('class'=>'InheritableLink', 'alias'=>'Link'));
+		$this->Image = ClassRegistry::init(array('class'=>'InheritableImage', 'alias'=>'Image'));
+
 	}
 
 /**
@@ -163,7 +159,7 @@ class InheritableTest extends CakeTestCase {
 		$r2 = $this->Article->find('all', array('conditions' => "permalink = 'about-us'"));
 		$this->__assertMatches('/Page[body=/CakePHP is a MVC PHP framework/i]', $r1);
 		$this->__assertMatches('/Article[body=/company/i]', $r2, "shit");
-		$this->assertNotEqual($r1, $r2);
+		$this->assertNotEquals($r1, $r2);
 	}
 
 /**

--- a/Test/Case/View/Helper/GravatarHelperTest.php
+++ b/Test/Case/View/Helper/GravatarHelperTest.php
@@ -128,11 +128,11 @@ class GravatarHelperTest extends CakeTestCase {
  * @access public
  */
 	public function testImageTag() {
-		$expected = '<img src="http://www.gravatar.com/avatar/' . Security::hash('example@gravatar.com', 'md5') . '" alt="" />';
+		$expected = '<img src="http://www.gravatar.com/avatar/' . Security::hash('example@gravatar.com', 'md5') . '" alt=""/>';
 		$result = $this->Gravatar->image('example@gravatar.com', array('ext' => false));
 		$this->assertEquals($expected, $result);
 
-		$expected = '<img src="http://www.gravatar.com/avatar/' . Security::hash('example@gravatar.com', 'md5') . '" alt="Gravatar" />';
+		$expected = '<img src="http://www.gravatar.com/avatar/' . Security::hash('example@gravatar.com', 'md5') . '" alt="Gravatar"/>';
 		$result = $this->Gravatar->image('example@gravatar.com', array('ext' => false, 'alt' => 'Gravatar'));
 		$this->assertEquals($expected, $result);
 	}


### PR DESCRIPTION
A single commit, including the following:
- Fixed name/alias mix-up in InheritableBehavior::afterFind(). Tests were failing.
- Added merge for parent/child $validate. Validation tests now pass, as both set of rules are merged.
- Fixed Tests
  - GravatarHelperTest - white space. 
  - CsvImportTest - case typo. 
  - InheritableTest - models are now instantiated using an alias.
- Updated .travis to CakePHP version 2.7.

I hope the above is compliant. If not, please let me know. 

Thanks
