### PR TITLE
Fix notice on atomic field

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -26,7 +26,6 @@ class SoftDeleteBehavior extends ModelBehavior {
  */
 	public $default = array(
 		'deleted' => 'deleted_date',
-		'atomic' => true,
 	);
 
 /**


### PR DESCRIPTION
#157 introduced a bug that triggers multiple Notice messages:

```
Notice (1024): SoftDeleteBehavior::setup(): model PropertyValue has no field!atomic [APP/Plugin/Utils/Model/Behavior/SoftDeleteBehavior.php, line 74]
Notice (1024): SoftDeleteBehavior::setup(): model EmailAddress has no field!atomic [APP/Plugin/Utils/Model/Behavior/SoftDeleteBehavior.php, line 74]
Notice (1024): SoftDeleteBehavior::setup(): model Property has no field!atomic [APP/Plugin/Utils/Model/Behavior/SoftDeleteBehavior.php, line 74]
Notice (1024): SoftDeleteBehavior::setup(): model Contact has no field!atomic [APP/Plugin/Utils/Model/Behavior/SoftDeleteBehavior.php, line 74]
```

It is easily fixed by removing:

```
 'atomic' => true,
```

from the `$default` array declaration. 

This is not needed as, a default value is already set by:

```
protected $_atomic = true;
```
