### PR TITLE
Add support for afterDelete() callback

### DIFF
--- a/Model/Behavior/SoftDeleteBehavior.php
+++ b/Model/Behavior/SoftDeleteBehavior.php
@@ -190,11 +190,13 @@ class SoftDeleteBehavior extends ModelBehavior {
 			unset($model->data[$model->alias]['updated']);
 			$result = $model->save(
 				array($model->alias => $data),
-				array('validate' => false, 'fieldList' => array_keys($data), 'atomic' => $this->_atomic)
+				array('validate' => false, 'fieldList' => array_keys($data), 'atomic' => $this->_atomic, 'callbacks' => false)
 			);
 			if (!$result) {
 				return false;
 			}
+
+			$model->getEventManager()->dispatch(new CakeEvent('Model.afterDelete', $model));
 		}
 
 		return true;


### PR DESCRIPTION
The proposed code dispatches a `Model.afterDelete` event once the softdelete has been completed, enabling the `afterDelete()` callback in the model.

It also prevents the `afterSave()` callback from being called by setting `'callbacks' => false` when updating the record.
